### PR TITLE
Adds a dedicated strategy for the Sandbox API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,15 @@ end
 
 ## Sandbox API
 
-Uphold supports a sandbox environment for testing purposes. To use it with this strategy, you'll need to use the following environment variables:
+Uphold supports a sandbox environment for testing purposes. To use it you will need a different strategy:
 
-```
-UPHOLD_URL="https://sandbox.uphold.com"
-UPHOLD_API_URL="https://api-sandbox.uphold.com"
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :uphold_sandbox, 'API_KEY', 'API_SECRET', name: :uphold
+end
 ```
 
-We recommend [dotenv](https://github.com/bkeepers/dotenv) for this.
+You can add `name: :uphold` to make sure it uses the same route names as if you were using the main strategy.
 
 ## Contributing
 

--- a/lib/omniauth-uphold.rb
+++ b/lib/omniauth-uphold.rb
@@ -1,2 +1,3 @@
 require 'omniauth-uphold/version'
 require 'omniauth/strategies/uphold'
+require 'omniauth/strategies/uphold_sandbox'

--- a/lib/omniauth-uphold/version.rb
+++ b/lib/omniauth-uphold/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Uphold
-    VERSION = '2.0.1'
+    VERSION = '2.1.1'
   end
 end

--- a/lib/omniauth/strategies/uphold.rb
+++ b/lib/omniauth/strategies/uphold.rb
@@ -5,18 +5,22 @@ module OmniAuth
     class Uphold < ::OmniAuth::Strategies::OAuth2
       include ::OmniAuth::Strategy
 
-      UPHOLD_URL = ENV['UPHOLD_URL'] || ENV['BITRESERVE_URL'] || 'https://uphold.com'
-      UPHOLD_API_URL = ENV['UPHOLD_API_URL'] || ENV['BITRESERVE_API_URL'] || 'https://api.uphold.com'
+      @uphold_url = 'https://uphold.com'
+      @uphold_api_url = 'https://api.uphold.com'
+
+      class << self
+        attr_reader :uphold_url, :uphold_api_url
+      end
 
       option :name, :uphold
       option :client_options, {
-        site: UPHOLD_API_URL,
+        site: @uphold_api_url,
         token_url: 'oauth2/token'
       }
 
       def initialize(app, *args, &block)
         super
-        options[:client_options][:authorize_url] = "#{UPHOLD_URL}/authorize/#{args[0]}"
+        options[:client_options][:authorize_url] = "#{self.class.uphold_url}/authorize/#{args[0]}"
       end
     end
   end

--- a/lib/omniauth/strategies/uphold_sandbox.rb
+++ b/lib/omniauth/strategies/uphold_sandbox.rb
@@ -1,0 +1,15 @@
+require 'omniauth-oauth2'
+
+module OmniAuth
+  module Strategies
+    class UpholdSandbox < ::OmniAuth::Strategies::Uphold
+      @uphold_url = 'https://sandbox.uphold.com'
+      @uphold_api_url = 'https://api-sandbox.uphold.com'
+
+      option :client_options, {
+        site: @uphold_api_url,
+        token_url: 'oauth2/token'
+      }
+    end
+  end
+end


### PR DESCRIPTION
Why:
- When developing apps on top of this gem, weird errors would occur depending
  on how `ENV` was loaded. The original approach depended on the fact that
  `ENV['UPHOLD_URL']` was defined before the strategy was loaded. This works
  when using `foreman`
  (which loads `.env` before starting Ruby) but not when using
  `dotenv-rails`, which would only load the classes have already been loaded.
  This would result in OmniAuth ignoring the ENV settings.

This change addresses the need by:
- Moving the sandbox URLs to a dedicated strategy, and turning constants into
  class variables.
